### PR TITLE
fix: resolve CodeQL failure by introducing Secret Scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,39 +2,25 @@ name: Security
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
   schedule:
     - cron: "34 17 * * 1"
 
 jobs:
-  analyze:
-    name: Analyze
+  secrets:
+    name: Secret Scanning
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["javascript"]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
         with:
-          category: "/language:${{matrix.language}}"
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified

--- a/README.md
+++ b/README.md
@@ -12,17 +12,22 @@ This repository is dedicated to defining and managing proper software requiremen
 2. **Key Files**:
     - `requirements.csv`: Contains the list of requirements with their properties.
     - `structure.csv`: Defines the document hierarchy (Parts and Sections).
+    - `assets/`: Directory for technical diagrams and supporting documentation.
+3. **Requirement Fields**:
     - `id`: Unique identifier (e.g., G.1.1).
     - `description`: Detailed explanation.
-    - `parent`: Parent requirement (e.g., G.1).
-    - `reference to`: Reference to other requirements (e.g., G.1.1).
-    - `attached files`: Attached files (e.g., assets/diagram.puml).
-    - `priority`: Priority (e.g., Must, Could, Should, Won't).
-3. **Automation**:
-    - Pushing changes to `requirements.csv` triggers a GitHub Action.
-    - The action uses [hugoglvs/pegs-specs-custom-action](https://github.com/hugoglvs/pegs-specs-custom-action) to generate specification artifacts.
+    - `parent`: Parent requirement for hierarchical nesting.
+    - `reference to`: References to related requirements.
+    - `attached files`: Path to local assets (e.g., `assets/diagram.puml`).
+    - `priority`: Management level (Must, Should, Could, Won't).
+4. **Automation**:
+    - Pushing changes to `requirements.csv` or `structure.csv` triggers a GitHub Action.
+    - The action uses [hugoglvs/pegs-specs-custom-action](https://github.com/hugoglvs/pegs-specs-custom-action) to generate and upload specifications as build artifacts.
+5. **Security**:
+    - Automatic **Secret Scanning** (via TruffleHog) is performed on every push to prevent accidental leaks of credentials or tokens within the requirements and documentation.
 
 ## Development
 - **Branching**: Use `feat/name` or `fix/name`.
-- **Commits**: Follow conventional commits.
+- **Commits**: Follow [Conventional Commits](https://www.conventionalcommits.org/).
+- **Validation**: All PRs must pass specification generation and security checks.
 - **Issues**: Use the provided templates for bugs and features.


### PR DESCRIPTION
## Description
The previous security workflow was failing because CodeQL is designed for source code analysis and this repository is strictly for generating specification document artifacts (Requirements as Code). 

Since there is no JavaScript, TypeScript, or Swift source code to analyze, I have:
- **Removed CodeQL** entirely to prevent CI failures.
- **Implemented Secret Scanning** using TruffleHog. This remains essential for a documentation-only repository to ensure no secrets or tokens are accidentally committed within the requirements or assets.
- Updated triggers to include the `dev` branch.

## Fixes
Fixes #14

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)